### PR TITLE
Add ZaloPay checkout with status polling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,13 @@
         "react-router-dom": "^7.8.0",
         "react-scripts": "5.0.1",
         "web-vitals": "^2.1.4"
+      },
+      "devDependencies": {
+        "@types/jest": "^30.0.0",
+        "@types/node": "^24.3.0",
+        "@types/react": "^19.1.10",
+        "@types/react-dom": "^19.1.7",
+        "typescript": "^5.9.2"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -2792,6 +2799,16 @@
         }
       }
     },
+    "node_modules/@jest/diff-sequences": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.0.1.tgz",
+      "integrity": "sha512-n5H8QLDJ47QqbCNn5SuFjCRDrOLEZ0h8vAHCK5RL9Ls7Xa8AQLa/YxAc9UjFqoEDM48muwtBGjtMY5cr0PLDCw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/@jest/environment": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-27.5.1.tgz",
@@ -2805,6 +2822,19 @@
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@jest/expect-utils": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.0.5.tgz",
+      "integrity": "sha512-F3lmTT7CXWYywoVUGTCmom0vXq3HTTkaZyTAzIy+bXSBizB7o5qzlC9VCtq0arOa8GqmNsbg/cE9C6HLn7Szew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.0.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/fake-timers": {
@@ -2824,6 +2854,16 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
+    "node_modules/@jest/get-type": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.0.1.tgz",
+      "integrity": "sha512-AyYdemXCptSRFirI5EPazNxyPwAL0jXt3zceFjaj8NFiKP9pOi0bfXonf6qkf82z2t3QWPeLCWWw4stPBzctLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/@jest/globals": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-27.5.1.tgz",
@@ -2836,6 +2876,30 @@
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@jest/pattern": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.0.1.tgz",
+      "integrity": "sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-regex-util": "30.0.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/pattern/node_modules/jest-regex-util": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.0.1.tgz",
+      "integrity": "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/reporters": {
@@ -4001,6 +4065,234 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "node_modules/@types/jest": {
+      "version": "30.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-30.0.0.tgz",
+      "integrity": "sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^30.0.0",
+        "pretty-format": "^30.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/@jest/schemas": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
+      "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/@jest/types": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.0.5.tgz",
+      "integrity": "sha512-aREYa3aku9SSnea4aX6bhKn4bgv3AXkgijoQgbYV3yvbiGt6z+MQ85+6mIhx9DsKW2BuB/cLR/A+tcMThx+KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.0.1",
+        "@jest/schemas": "30.0.5",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/@sinclair/typebox": {
+      "version": "0.34.40",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.40.tgz",
+      "integrity": "sha512-gwBNIP8ZAYev/ORDWW0QvxdwPXwxBtLsdsJgSc7eDIRt8ubP+rxUBzPsrwnu16fgEF8Bx4lh/+mvQvJzcTM6Kw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/jest/node_modules/@types/yargs": {
+      "version": "17.0.33",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
+      "integrity": "sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/jest/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@types/jest/node_modules/ci-info": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.0.tgz",
+      "integrity": "sha512-l+2bNRMiQgcfILUi33labAZYIWlH1kWDp+ecNo5iisRKrbm0xcRyCww71/YU0Fkw0mAFpz9bJayXPjey6vkmaQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@types/jest/node_modules/expect": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-30.0.5.tgz",
+      "integrity": "sha512-P0te2pt+hHI5qLJkIR+iMvS+lYUZml8rKKsohVHAGY+uClp9XVbdyYNJOIjSRpHVp8s8YqxJCiHUkSYZGr8rtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/expect-utils": "30.0.5",
+        "@jest/get-type": "30.0.1",
+        "jest-matcher-utils": "30.0.5",
+        "jest-message-util": "30.0.5",
+        "jest-mock": "30.0.5",
+        "jest-util": "30.0.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-diff": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.0.5.tgz",
+      "integrity": "sha512-1UIqE9PoEKaHcIKvq2vbibrCog4Y8G0zmOxgQUVEiTqwR5hJVMCoDsN1vFvI5JvwD37hjueZ1C4l2FyGnfpE0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/diff-sequences": "30.0.1",
+        "@jest/get-type": "30.0.1",
+        "chalk": "^4.1.2",
+        "pretty-format": "30.0.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-matcher-utils": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.0.5.tgz",
+      "integrity": "sha512-uQgGWt7GOrRLP1P7IwNWwK1WAQbq+m//ZY0yXygyfWp0rJlksMSLQAA4wYQC3b6wl3zfnchyTx+k3HZ5aPtCbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.0.1",
+        "chalk": "^4.1.2",
+        "jest-diff": "30.0.5",
+        "pretty-format": "30.0.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-message-util": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.0.5.tgz",
+      "integrity": "sha512-NAiDOhsK3V7RU0Aa/HnrQo+E4JlbarbmI3q6Pi4KcxicdtjV82gcIUrejOtczChtVQR4kddu1E1EJlW6EN9IyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@jest/types": "30.0.5",
+        "@types/stack-utils": "^2.0.3",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "micromatch": "^4.0.8",
+        "pretty-format": "30.0.5",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-mock": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.0.5.tgz",
+      "integrity": "sha512-Od7TyasAAQX/6S+QCbN6vZoWOMwlTtzzGuxJku1GhGanAjz9y+QsQkpScDmETvdc9aSXyJ/Op4rhpMYBWW91wQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.0.5",
+        "@types/node": "*",
+        "jest-util": "30.0.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-util": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.0.5.tgz",
+      "integrity": "sha512-pvyPWssDZR0FlfMxCBoc0tvM8iUEskaRFALUtGQYzVEAqisAztmy+R8LnU14KT4XA0H/a5HMVTXat1jLne010g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.0.5",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@types/jest/node_modules/pretty-format": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.0.5.tgz",
+      "integrity": "sha512-D1tKtYvByrBkFLe2wHJl2bwMJIiT8rW+XA+TiataH79/FszLQMrpGEvzUVkzPau7OCO0Qnrhpe87PqtOAIB8Yw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.0.5",
+        "ansi-styles": "^5.2.0",
+        "react-is": "^18.3.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -4020,9 +4312,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.2.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.2.1.tgz",
-      "integrity": "sha512-DRh5K+ka5eJic8CjH7td8QpYEV6Zo10gfRkjHCO3weqZHWDtAaSTFtl4+VMqOJ4N5jcuhZ9/l+yy8rVgw7BQeQ==",
+      "version": "24.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
+      "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.10.0"
@@ -4066,6 +4358,26 @@
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
       "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "19.1.10",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.10.tgz",
+      "integrity": "sha512-EhBeSYX0Y6ye8pNebpKrwFJq7BoQ8J5SO6NlvNwwHjSj6adXJViPQrKlsyPw7hLBLvckEMO1yxeGdR82YBBlDg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.1.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.7.tgz",
+      "integrity": "sha512-i5ZzwYpqjmrKenzkoLM2Ibzt6mAsM7pxB6BCIouEVVmgiqaMj1TjaK7hnA36hbW5aZv20kx7Lw6hWzPWg0Rurw==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.0.0"
+      }
     },
     "node_modules/@types/resolve": {
       "version": "1.17.1",
@@ -17457,17 +17769,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -40,5 +40,12 @@
       "last 1 safari version"
     ]
   },
-  "proxy": "http://localhost:8080"
+  "proxy": "http://localhost:8080",
+  "devDependencies": {
+    "@types/jest": "^30.0.0",
+    "@types/node": "^24.3.0",
+    "@types/react": "^19.1.10",
+    "@types/react-dom": "^19.1.7",
+    "typescript": "^5.9.2"
+  }
 }

--- a/src/api/payments.ts
+++ b/src/api/payments.ts
@@ -1,0 +1,29 @@
+import axios from 'axios';
+import appsettings from '../appsettings';
+
+export async function checkout(subscriptionId: number, amount: number) {
+  try {
+    const response = await axios.post(`${appsettings.apiBaseUrl}/payments/checkout`, {
+      subscriptionId,
+      amount,
+    });
+    const data = response.data;
+    return {
+      txId: data.txId,
+      payUrl: data.payUrl ?? data.order?.order_url,
+    };
+  } catch (error) {
+    console.error('Error creating payment order:', error);
+    throw error;
+  }
+}
+
+export async function getTxStatus(txId: number) {
+  try {
+    const response = await axios.get(`${appsettings.apiBaseUrl}/payments/tx/${txId}/status`);
+    return response.data;
+  } catch (error) {
+    console.error('Error fetching transaction status:', error);
+    throw error;
+  }
+}

--- a/src/components/PayButton.tsx
+++ b/src/components/PayButton.tsx
@@ -1,0 +1,47 @@
+import React, { useEffect, useState } from 'react';
+import { Button, message } from 'antd';
+import { checkout } from '../api/payments';
+import usePaymentPoller from '../hooks/usePaymentPoller';
+
+interface PayButtonProps {
+  subscriptionId: number;
+  amount: number;
+  onPaid?: () => void;
+}
+
+const PayButton: React.FC<PayButtonProps> = ({ subscriptionId, amount, onPaid }) => {
+  const [txId, setTxId] = useState<number | undefined>();
+  const status = usePaymentPoller(txId);
+
+  useEffect(() => {
+    if (status === 'Paid') {
+      onPaid?.();
+    }
+  }, [status, onPaid]);
+
+  const handlePay = async () => {
+    const payWin = window.open('', '_blank');
+    try {
+      const { txId, payUrl } = await checkout(subscriptionId, amount);
+      setTxId(txId);
+      if (payWin) {
+        payWin.location.href = payUrl;
+      }
+    } catch (error) {
+      payWin?.close();
+      console.error('Checkout error:', error);
+      message.error('Không thể khởi tạo thanh toán');
+    }
+  };
+
+  return (
+    <div>
+      <Button type="primary" onClick={handlePay}>
+        Thanh toán
+      </Button>
+      {txId && <div>Trạng thái: {status}</div>}
+    </div>
+  );
+};
+
+export default PayButton;

--- a/src/context/UserContext.js
+++ b/src/context/UserContext.js
@@ -1,4 +1,6 @@
 import React, { createContext, useState, useEffect } from 'react';
+import axios from 'axios';
+import appsettings from '../appsettings';
 
 export const UserContext = createContext();
 
@@ -16,8 +18,21 @@ export const UserProvider = ({ children }) => {
     }
   }, [user]);
 
+  const refetchUser = async () => {
+    try {
+      const token = user?.token;
+      if (!token) return;
+      const response = await axios.get(`${appsettings.apiBaseUrl}/auth/me`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      setUser({ ...user, ...response.data });
+    } catch (error) {
+      console.error('Error refetching user:', error);
+    }
+  };
+
   return (
-    <UserContext.Provider value={{ user, setUser }}>
+    <UserContext.Provider value={{ user, setUser, refetchUser }}>
       {children}
     </UserContext.Provider>
   );

--- a/src/hooks/usePaymentPoller.ts
+++ b/src/hooks/usePaymentPoller.ts
@@ -1,0 +1,57 @@
+import { useEffect, useState } from 'react';
+import { getTxStatus } from '../api/payments';
+
+export type PaymentStatus = 'Idle' | 'Pending' | 'Paid' | 'Failed' | 'Timeout';
+
+interface Options {
+  intervalMs?: number;
+  timeoutMs?: number;
+}
+
+export function usePaymentPoller(
+  txId?: number,
+  { intervalMs = 3000, timeoutMs = 120000 }: Options = {},
+): PaymentStatus {
+  const [status, setStatus] = useState<PaymentStatus>('Idle');
+
+  useEffect(() => {
+    if (!txId) {
+      setStatus('Idle');
+      return;
+    }
+
+    let active = true;
+    const start = Date.now();
+
+    const poll = async () => {
+      if (!active) return;
+      try {
+        const data = await getTxStatus(txId);
+        const currentStatus = data.status as PaymentStatus;
+        if (currentStatus === 'Pending') {
+          if (Date.now() - start >= timeoutMs) {
+            setStatus('Timeout');
+            return;
+          }
+          setStatus('Pending');
+          setTimeout(poll, intervalMs);
+        } else {
+          setStatus(currentStatus === 'Paid' ? 'Paid' : 'Failed');
+        }
+      } catch (error) {
+        console.error('Polling error:', error);
+        setStatus('Failed');
+      }
+    };
+
+    poll();
+
+    return () => {
+      active = false;
+    };
+  }, [txId, intervalMs, timeoutMs]);
+
+  return status;
+}
+
+export default usePaymentPoller;

--- a/src/pages/HomePage.js
+++ b/src/pages/HomePage.js
@@ -1,12 +1,12 @@
-import React, { useEffect, useState } from 'react';
-import axios from 'axios';
-import { Layout, Typography, Button, Row, Col, Space } from 'antd';
+import React, { useEffect, useState, useContext } from 'react';
+import { Layout, Typography, Row, Col, Space, message } from 'antd';
 import { CheckCircleOutlined } from '@ant-design/icons';
-import { Link } from 'react-router-dom';
 import Header from '../components/Header';
 import Footer from '../components/Footer';
 import Card from '../components/Card';
 import { fetchBooks } from '../api/books';
+import PayButton from '../components/PayButton';
+import { UserContext } from '../context/UserContext';
 import '../styles/HomePage.css';
 
 const { Content } = Layout;
@@ -14,6 +14,7 @@ const { Title, Paragraph } = Typography;
 
 function HomePage() {
   const [books, setBooks] = useState([]);
+  const { refetchUser } = useContext(UserContext);
 
   useEffect(() => {
     const loadBooks = async () => {
@@ -28,31 +29,39 @@ function HomePage() {
     loadBooks();
   }, []);
 
+  const handlePaid = async () => {
+    await refetchUser();
+    message.success('Thanh toán thành công');
+  };
+
   const plans = [
     {
       title: 'Basic',
       price: '$5/month',
       description: 'Perfect for casual readers.',
-      onClick: () => alert('Subscribed to Basic Plan!'),
+      subscriptionId: 1,
+      amount: 5,
     },
     {
       title: 'Premium',
       price: '$10/month',
       description: 'Ideal for avid readers.',
-      onClick: () => alert('Subscribed to Premium Plan!'),
+      subscriptionId: 2,
+      amount: 10,
     },
     {
       title: 'Elite',
       price: '$20/month',
       description: 'Unlimited access to all features.',
-      onClick: () => alert('Subscribed to Elite Plan!'),
+      subscriptionId: 3,
+      amount: 20,
     },
   ];
 
   const features = [
-    { text: 'Access thousands of books anytime, anywhere.', icon: <CheckCircleOutlined/> },
-    { text: 'Flexible subscription plans to suit your needs.', icon: <CheckCircleOutlined/> },
-    { text: 'Curated recommendations just for you.', icon: <CheckCircleOutlined/> },
+    { text: 'Access thousands of books anytime, anywhere.', icon: <CheckCircleOutlined /> },
+    { text: 'Flexible subscription plans to suit your needs.', icon: <CheckCircleOutlined /> },
+    { text: 'Curated recommendations just for you.', icon: <CheckCircleOutlined /> },
   ];
 
   return (
@@ -83,9 +92,11 @@ function HomePage() {
                 >
                   <Paragraph className="subscription-price">{plan.price}</Paragraph>
                   <Paragraph className="subscription-description">{plan.description}</Paragraph>
-                  <Button type="primary" onClick={plan.onClick}>
-                    Subscribe
-                  </Button>
+                  <PayButton
+                    subscriptionId={plan.subscriptionId}
+                    amount={plan.amount}
+                    onPaid={handlePaid}
+                  />
                 </Card>
               </Col>
             ))}

--- a/src/pages/UserDashboard.js
+++ b/src/pages/UserDashboard.js
@@ -1,27 +1,41 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useContext } from 'react';
 import Header from '../components/Header';
-import { Layout } from 'antd';
+import { Layout, message } from 'antd';
 import '../styles/UserDashboard.css';
 import Card from '../components/Card';
 import { fetchSubscriptionStatus } from '../api/subscriptions';
+import PayButton from '../components/PayButton';
+import { UserContext } from '../context/UserContext';
 
 const { Content, Footer } = Layout;
 
 function UserDashboard() {
   const [subscriptionStatus, setSubscriptionStatus] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const { refetchUser } = useContext(UserContext);
+
+  const loadSubscriptionStatus = async () => {
+    try {
+      const data = await fetchSubscriptionStatus();
+      setSubscriptionStatus(data);
+    } catch (error) {
+      console.error('Error loading subscription status:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
 
   useEffect(() => {
-    const loadSubscriptionStatus = async () => {
-      try {
-        const data = await fetchSubscriptionStatus();
-        setSubscriptionStatus(data);
-      } catch (error) {
-        console.error('Error loading subscription status:', error);
-      }
-    };
-
     loadSubscriptionStatus();
   }, []);
+
+  const handlePaid = async () => {
+    await refetchUser();
+    await loadSubscriptionStatus();
+    message.success('Thanh toán thành công');
+  };
+
+  const showPayButton = !loading && (!subscriptionStatus || new Date(subscriptionStatus.endDate) < new Date());
 
   return (
     <Layout className="UserDashboard">
@@ -35,21 +49,19 @@ function UserDashboard() {
             <h2>Subscription Management</h2>
             <p>Manage your active subscriptions and explore new plans.</p>
             <Card className="dashboard-card">
-              {subscriptionStatus ? (
+              {loading ? (
+                <p>Loading subscription details...</p>
+              ) : showPayButton ? (
+                <div>
+                  <p>No active subscription.</p>
+                  <PayButton subscriptionId={1} amount={5} onPaid={handlePaid} />
+                </div>
+              ) : (
                 <ul>
                   <li>Plan Name: {subscriptionStatus.planName}</li>
                   <li>Start Date: {new Date(subscriptionStatus.startDate).toLocaleDateString()}</li>
                   <li>End Date: {new Date(subscriptionStatus.endDate).toLocaleDateString()}</li>
-                  {/* <li>Status: {subscriptionStatus.status}</li>
-                  <li>Max Borrow Per Day: {subscriptionStatus.maxPerDay}</li>
-                  <li>Max Borrow Per Month: {subscriptionStatus.maxPerMonth}</li>
-                  <li>Borrowed Today: {subscriptionStatus.borrowedToday}</li>
-                  <li>Borrowed This Month: {subscriptionStatus.borrowedThisMonth}</li>
-                  <li>Remaining Today: {subscriptionStatus.remainingToday}</li>
-                  <li>Remaining This Month: {subscriptionStatus.remainingThisMonth}</li> */}
                 </ul>
-              ) : (
-                <p>Loading subscription details...</p>
               )}
             </Card>
           </section>
@@ -68,8 +80,7 @@ function UserDashboard() {
           <section className="UserDashboard-section">
             <h2>Account Details</h2>
             <p>Update your personal information and preferences.</p>
-            <Card className="dashboard-card">
-            </Card>
+            <Card className="dashboard-card"></Card>
           </section>
         </Content>
       </Layout>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- add payments API helpers for ZaloPay checkout and transaction status
- provide polling hook and PayButton component to open payment and watch status
- integrate payment button on Home and Dashboard with user refresh

## Testing
- `CI=true npm test` *(fails: Cannot find module 'react-router-dom' from 'src/App.js')*

------
https://chatgpt.com/codex/tasks/task_e_68a6b22f1cd48324b4fa388da0b55474